### PR TITLE
Modify the organization name to infoblox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT  := infobloxopen/buildtool
+PROJECT  := infoblox/buildtool
 
 # The list of buildtool versions we are going to build,
 # make all versions as phony rules, so we will rebuild

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ To compile the Go binary using the provided tool, you could start with the follo
 where ```project``` variable defines the Go project:
 ```sh
 docker run --rm -v $(pwd):/go/src/${project} \
-    infobloxopen/buildtool:v1 go build -o binary
+    infoblox/buildtool:v1 go build -o binary
 ```


### PR DESCRIPTION
This patch updates the build pipeline as well as the
documentation to modify the organization name to one,
used in the docker hub.
