### PR TITLE
Change version of Go compiler to 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PROJECT  := infoblox/buildtool
-LATEST   := latest
 
 .PHONY: all clean latest
 all: latest
@@ -7,8 +6,8 @@ all: latest
 
 # Create the Docker image with the latest tag.
 latest:
-	docker build -t $(PROJECT):$@ $(LATEST)
+	docker build -t $(PROJECT):$@ buildtool
 
 
 clean:
-	docker rmi -f $(PROJECT):$(LATEST)
+	docker rmi -f $(PROJECT):latest

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This repository provides the set of the Docker images used to compile the Go pro
 
 The build of the Docker image require the [docker](https://docs.docker.com/engine/installation/)
 engine and the ```make``` utility as pre-requisites. As the requirements are satisfied, use the
-following command to compile the Docker image of version ```v1```:
+following command to compile the ```latest``` version of the Docker image:
 ```sh
-make v1
+make latest
 ```
 
 ## Usage
@@ -17,5 +17,5 @@ To compile the Go binary using the provided tool, you could start with the follo
 where ```project``` variable defines the Go project:
 ```sh
 docker run --rm -v $(pwd):/go/src/${project} \
-    infoblox/buildtool:v1 go build -o binary
+    infoblox/buildtool:latest go build -o binary
 ```

--- a/buildtool/Dockerfile
+++ b/buildtool/Dockerfile
@@ -1,24 +1,15 @@
 # The docker image to build the binaries.
-FROM golang:1.5.3
+FROM golang:1.7
 MAINTAINER Yakau Bubnou <ybubnou@infoblox.com>
 WORKDIR /tmp
 
 # Set up mandatory Go environmental variables.
-ENV GO15VENDOREXPERIMENT=1
 ENV CGO_ENABLED=0
 
-# Install zip tool to unpack the protoc compiler, and the npm
-# package manager and install the REST API generator.
+# Install zip tool to unpack the protoc compiler.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        unzip \
-        nodejs \
-        npm \
-    && rm -rf /var/lib/apt/lists/*
-
-# Soon, we will switch to the swagger-based documentation, so it could
-# not be longer required.
-RUN npm install -g apidoc && ln -sf $(which nodejs) /usr/bin/node
+    && apt-get install -y --no-install-recommends unzip \
+    && apt-get clean
 
 # The version and the binaries checksum for the protocol buffers compiler.
 ENV PROTOC_VERSION 3.0.0


### PR DESCRIPTION
This patch modifies the version of the Go compiler to 1.7. Also it
remove no longer needed documentation generation tool "apidoc" as
well as its respective dependencies "npm" and "nodejs".