### PR TITLE
Fix Docker Hub images 'Full Description'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ make latest
 
 ## Usage
 
-To compile the Go binary using the provided tool, you could start with the following command,
-where ```project``` variable defines the Go project:
+To compile the Go binary using one of the provided tools, you could start with the following
+command:
 ```sh
 docker run --rm -v $(pwd):/go/src/${project} \
-    infoblox/buildtool:latest go build -o binary
+    infoblox/${buildtool-name}:latest go build -o binary
 ```
+Where,
+```project``` variable defines the Go project;
+```buildtool-name``` variable defines build tool Docker image name (e.g. buildtool, buildtool-alpine).


### PR DESCRIPTION
Docker Hub shows the same 'Full Description', which built from
Readme.md file, for two different Docker images, placed in one
GitHub repo: infoblox/buildtool and infoblox/buildtool-alpine.
So fixed images 'Full Description' here to be more universal.


Docker Hub before changes:
![selection_001](https://user-images.githubusercontent.com/7091950/46031460-92fd4500-c101-11e8-8976-af72231e9d12.png)
![selection_002](https://user-images.githubusercontent.com/7091950/46031470-98f32600-c101-11e8-8093-22ef59f3e9cc.png)
