### PR TITLE
reduce the diff between Dockerfiles

### DIFF
--- a/buildtool-alpine/Dockerfile
+++ b/buildtool-alpine/Dockerfile
@@ -1,6 +1,5 @@
 # The docker image to build the go binaries
 FROM golang:1.12-alpine3.9
-MAINTAINER Uladzimir Trehubenka <utrehubenka@infoblox.com>
 WORKDIR /tmp
 
 # Install build tools
@@ -10,7 +9,7 @@ RUN apk update --no-cache && \
     apk upgrade --no-cache && \
     apk add --no-cache $PKG
 
-# The version and the binaries checksum for the glide package manager
+# The version and the binaries checksum for the glide package manager.
 ENV GLIDE_VERSION 0.13.2
 ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/v${GLIDE_VERSION}/glide-v${GLIDE_VERSION}-linux-amd64.tar.gz
 ENV GLIDE_DOWNLOAD_SHA256 11b161e1c1acde4bf4e0e4bdedac36f920d184f7b165e9fc4161cf6aab147eaf
@@ -34,10 +33,11 @@ RUN glide up --strip-vendor --skip-test \
     && go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
     && rm -rf vendor/* ${GOPATH}/pkg/* ${GOPATH}/src/*
 
-# Install the Go linter and Go junit binary
-RUN go get golang.org/x/lint/golint \
-    && go get github.com/jstemmer/go-junit-report \
-    && go get github.com/golang/dep/cmd/dep \
+# Install the Go linter binary, and JUnit report generator.
+RUN go get \
+    golang.org/x/lint/golint \
+    github.com/jstemmer/go-junit-report \
+    github.com/golang/dep/cmd/dep \
     && rm -rf ${GOPATH}/pkg/* ${GOPATH}/src/*
 
 WORKDIR ${GOPATH}

--- a/buildtool/Dockerfile
+++ b/buildtool/Dockerfile
@@ -1,6 +1,5 @@
-# The docker image to build the binaries.
+# The docker image to build the go binaries
 FROM golang:1.9.2
-MAINTAINER Anton Mikhnavets <amikhnavets@infoblox.com>
 WORKDIR /tmp
 
 # Set up mandatory Go environmental variables.
@@ -22,10 +21,10 @@ RUN curl -fsSL ${PROTOC_DOWNLOAD_URL} -o protoc.zip \
     && unzip -d /usr/local protoc.zip \
     && rm -rf protoc.zip
 
-# The version and the binaries chechsum for the glide package manager.
-ENV GLIDE_VERSION 0.12.3
+# The version and the binaries checksum for the glide package manager.
+ENV GLIDE_VERSION 0.13.2
 ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/v${GLIDE_VERSION}/glide-v${GLIDE_VERSION}-linux-amd64.tar.gz
-ENV GLIDE_DOWNLOAD_SHA256 0e2be5e863464610ebc420443ccfab15cdfdf1c4ab63b5eb25d1216900a75109
+ENV GLIDE_DOWNLOAD_SHA256 11b161e1c1acde4bf4e0e4bdedac36f920d184f7b165e9fc4161cf6aab147eaf
 
 # Download and install the glide package manager.
 RUN curl -fsSL ${GLIDE_DOWNLOAD_URL} -o glide.tar.gz \
@@ -33,7 +32,7 @@ RUN curl -fsSL ${GLIDE_DOWNLOAD_URL} -o glide.tar.gz \
     && tar -xzf glide.tar.gz --strip-components=1 -C /usr/local/bin \
     && rm -rf glide.tar.gz
 
-# Install as the protoc plugins as build-time dependecies.
+# Install as the protoc plugins as build-time dependencies
 COPY glide.yaml .
 
 # Compile binaries for the protocol buffer plugins. We need specific
@@ -48,7 +47,7 @@ RUN glide up --strip-vendor --skip-test \
 
 # Install the Go linter binary, and JUnit report generator.
 RUN go get \
-    github.com/golang/lint/golint \
+    golang.org/x/lint/golint \
     github.com/jstemmer/go-junit-report \
     github.com/golang/dep/cmd/dep \
     && rm -rf ${GOPATH}/pkg/* ${GOPATH}/src/*


### PR DESCRIPTION
These two dockerfiles are very similar and should be consolidated. As a first pass, this PR removes their trivia differences. Here's the diff after this PR:
```diff
% diff -u buildtool*/Dockerfile        
--- buildtool-alpine/Dockerfile 2020-11-19 17:09:54.000000000 -0800
+++ buildtool/Dockerfile        2020-11-19 17:10:17.000000000 -0800
@@ -1,13 +1,25 @@
 # The docker image to build the go binaries
-FROM golang:1.12-alpine3.9
+FROM golang:1.9.2
 WORKDIR /tmp
 
-# Install build tools
-ENV PKG bash curl gcc git linux-headers make musl-dev openssh protobuf unzip
+# Set up mandatory Go environmental variables.
+ENV CGO_ENABLED=0
 
-RUN apk update --no-cache && \
-    apk upgrade --no-cache && \
-    apk add --no-cache $PKG
+# Install zip tool to unpack the protoc compiler.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && apt-get clean
+
+# The version and the binaries checksum for the protocol buffers compiler.
+ENV PROTOC_VERSION 3.0.0
+ENV PROTOC_DOWNLOAD_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+ENV PROTOC_DOWNLOAD_SHA256 56e3f685ffe3c9516c5ed1da0aefd3f41010a051e8b36f1b538ac23298fccb30
+
+# Download and install the protocol buffers compiler.
+RUN curl -fsSL ${PROTOC_DOWNLOAD_URL} -o protoc.zip \
+    && echo "${PROTOC_DOWNLOAD_SHA256} protoc.zip" | sha256sum -c - \
+    && unzip -d /usr/local protoc.zip \
+    && rm -rf protoc.zip
 
 # The version and the binaries checksum for the glide package manager.
 ENV GLIDE_VERSION 0.13.2
```