### PR TITLE
update buildtool-alpine

### DIFF
--- a/buildtool-alpine/Dockerfile
+++ b/buildtool-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # The docker image to build the go binaries
-FROM golang:1.12-alpine3.9
+FROM golang:1.15.4-alpine3.12
 WORKDIR /tmp
 
 # Install build tools


### PR DESCRIPTION
Dependabot was reporting:
> updater | INFO <job_70467321> No update needed for golang 1.12-alpine3.9

This PR updates it manually, but I intentionally left it one version down to see if Dependabot could handle bumping it a smaller increment. If not, we can follow up with some other automation to do it.